### PR TITLE
Standardize changelog.md, Add variant_type check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,60 +1,68 @@
 # Changelog
 All notable changes to the call-gSV pipeline.
 
+---
+
 ## [Unreleased]
+
+---
+
+## [4.0.0-rc.1] - 2022-04-01
 ### Added
-- Added the Issue Report template
-- Added the Pull Request template
-- Added GPL 2.0
+- Add the Issue Report template
+- Add the Pull Request template
+- Add GPL 2.0
 
 ### Fixed
-- Fixed Issue #32: remove option '--exclude' in delly cnv
-- Fixed Issue #33: should pass the mappability_map file instead of the exclusion file to regenotype_gCNV_Delly
+- Fix Issue #32: remove option '--exclude' in delly cnv
+- Fix Issue #33: should pass the mappability_map file instead of the exclusion file to regenotype_gCNV_Delly
 
 ### Changed
-- Storing variant_type,reference_fasta,reference_fasta_index in the input file is rigid, also duplacating a same value many times. Now store these values in the nextflow.config. 
-- Changed partition types from lowmem/midmem/execute to F2/F32/F72/M64.
+- Change the input file schema by removing variant_type,reference_fasta,reference_fasta_index, put them into template.config. 
+- Change partition types from lowmem/midmem/execute to F2/F32/F72/M64.
+- Standardize the output structure.
+- Standardize the configuration structure.
 
 ---
 
 ## [3.0.0] - 2021-07-01
 ### Added
-- Added ability to call germline SVs with Manta
-- Added parameters to control which SV caller is used (run_delly & run_manta)
-- Added pipeline version from manifest to pipeline logging output
-- Added CNV VCF outputs to QC processes
-- Added two new processes to regenotype SVs or CNVs with Delly (regenotype_gSV_Delly & regenotype_gCNV_Delly)
-- Added parameters and input variant_type to control which type of regenotyping is run (variant_type, run_regenotyping & run_discovery)
+- Add ability to call germline SVs with Manta
+- Add parameters to control which SV caller is used (run_delly & run_manta)
+- Add pipeline version from manifest to pipeline logging output
+- Add CNV VCF outputs to QC processes
+- Add two new processes to regenotype SVs or CNVs with Delly (regenotype_gSV_Delly & regenotype_gCNV_Delly)
+- Add parameters and input variant_type to control which type of regenotyping is run (variant_type, run_regenotyping & run_discovery)
 
 ### Changed
-- Changed output directories to correspond with tool name casing
+- Change output directories to correspond with tool name casing
 
 ## [2.2.0] - 2021-05-07
 ### Changed
-- Updated modules to point to tool specific Docker Hub repos
+- Update modules to point to tool specific Docker Hub repos
 - Update of BCFtools from 1.11 to 1.12
 - Update of RTG-tools from 3.11 to 3.12
 
 ## [2.1.0] - 2021-04-01
 ### Added
-- Added Validate-nf logging outputs to output logging directory
+- Add Validate-nf logging outputs to output logging directory
 
 ### Changed
-- Updated Validate-nf tool version from 1.0.0 to 2.1.0 (Resolves issue #18)
+- Update Validate-nf tool version from 1.0.0 to 2.1.0 (Resolves issue #18)
 
 ## [2.0.0] - 2021-03-30
 ### Added
-- Implementation of Delly CNV, with output file conversions and SHA512s
-- Added mappability map to config inputs
+- Implement of Delly CNV, with output file conversions and SHA512s
+- Add mappability map to config inputs
 
 ### Changed
-- Updated Delly dockerfile to use bl-base
-- Output files now include a tag of "SV" or "CNV", as appropriate
+- Update Delly dockerfile to use bl-base
+- Include a tag of "SV" or "CNV" in output files, as appropriate
 
 ## [1.0.1] - 2021-03-04
 ### Changed
-- Changed Docker run permissions (docker.sudo and docker.runOptions)
-- Fixes issue #9
+- Change Docker run permissions (docker.sudo and docker.runOptions)
+- Fix issue #9
 
 ## [1.0.0] - 2021-03-01
 ### Added

--- a/pipeline/call-gSV.nf
+++ b/pipeline/call-gSV.nf
@@ -56,6 +56,23 @@ include { run_vcf_validator_VCFtools as run_gSV_vcf_validator_VCFtools; run_vcf_
 include { run_sha512sum as run_sha512sum_gSV_Delly; run_sha512sum as run_sha512sum_gCNV_Delly; run_sha512sum as run_sha512sum_regeno_gSV_Delly; run_sha512sum as run_sha512sum_regeno_gCNV_Delly } from './modules/sha512' addParams(docker_image_name: "$params.docker_image_delly".toUpperCase())
 include { run_sha512sum as run_sha512sum_Manta } from './modules/sha512' addParams(docker_image_name: "$params.docker_image_manta")
 
+
+checked_variant_type = []
+if (params.run_delly || params.run_regenotyping) {
+    for (vt in params.variant_type) {
+        if ('gsv' == vt.toLowerCase() || 'sv' == vt.toLowerCase()) {
+            checked_variant_type.add(params.GSV)
+            }
+        if ('gcnv' == vt.toLowerCase() || 'cnv' == vt.toLowerCase()) {
+            checked_variant_type.add(params.GCNV)
+            }
+        }
+    if (checked_variant_type.isEmpty()) {
+        throw new Exception("ERROR: checked_variant_type cannot be empty")
+        }
+    }
+
+
 input_bam_ch = Channel
     .fromPath(params.input_csv, checkIfExists:true)
     .splitCsv(header:true)
@@ -109,7 +126,7 @@ workflow {
             convert_gSV_BCF2VCF_BCFtools(call_gSV_Delly.out.bcf_sv_file, call_gSV_Delly.out.bam_sample_name, params.GSV)
             run_sha512sum_gSV_Delly(call_gSV_Delly.out.bcf_sv_file.mix(call_gSV_Delly.out.bcf_sv_file_csi))
 
-            if (params.variant_type.contains(params.GCNV)) {
+            if (checked_variant_type.contains(params.GCNV)) {
                 call_gCNV_Delly(input_bam_ch, call_gSV_Delly.out.bcf_sv_file.toList(), params.reference_fasta, reference_fasta_index, params.mappability_map)
                 convert_gCNV_BCF2VCF_BCFtools(call_gCNV_Delly.out.bcf_cnv_file, call_gCNV_Delly.out.bam_sample_name, params.GCNV)
                 run_sha512sum_gCNV_Delly(call_gCNV_Delly.out.bcf_cnv_file.mix(call_gCNV_Delly.out.bcf_cnv_file_csi))
@@ -119,7 +136,7 @@ workflow {
                 run_gSV_vcfstats_RTGTools(convert_gSV_BCF2VCF_BCFtools.out.vcf_file, call_gSV_Delly.out.bam_sample_name, params.GSV)
                 run_gSV_vcf_validator_VCFtools(convert_gSV_BCF2VCF_BCFtools.out.vcf_file, call_gSV_Delly.out.bam_sample_name, params.GSV)
 
-                if (params.variant_type.contains(params.GCNV)) {
+                if (checked_variant_type.contains(params.GCNV)) {
                     run_gCNV_vcfstats_RTGTools(convert_gCNV_BCF2VCF_BCFtools.out.vcf_file, call_gCNV_Delly.out.bam_sample_name, params.GCNV)
                     run_gCNV_vcf_validator_VCFtools(convert_gCNV_BCF2VCF_BCFtools.out.vcf_file, call_gCNV_Delly.out.bam_sample_name, params.GCNV)
                     }
@@ -129,12 +146,12 @@ workflow {
     // When 'run_regenotyping' is set to true, the variant_type specified in the input_csv will be used to determine which
     // regenotyping process to run. For example, if the variant_type contains 'gSV', regenotype_gSV_Delly will run, etc.
     if (params.run_regenotyping) {
-        if (params.variant_type.contains(params.GSV)) {
+        if (checked_variant_type.contains(params.GSV)) {
             regenotype_gSV_Delly(input_bam_ch, params.reference_fasta, reference_fasta_index, params.exclusion_file, params.merged_sites_gSV)
             run_sha512sum_regeno_gSV_Delly(regenotype_gSV_Delly.out.regenotyped_sv_bcf.mix(regenotype_gSV_Delly.out.regenotyped_sv_bcf_csi))
         }
 
-        if (params.variant_type.contains(params.GCNV)) {
+        if (checked_variant_type.contains(params.GCNV)) {
             regenotype_gCNV_Delly(input_bam_ch, params.reference_fasta, reference_fasta_index, params.mappability_map, params.merged_sites_gCNV)
             run_sha512sum_regeno_gCNV_Delly(regenotype_gCNV_Delly.out.regenotyped_cnv_bcf.mix(regenotype_gCNV_Delly.out.regenotyped_cnv_bcf_csi))
         }


### PR DESCRIPTION
<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I have read the [code review guidelines](https://confluence.mednet.ucla.edu/display/BOUTROSLAB/Code+Review+Guidelines) and the [code review best practice on GitHub check-list](https://confluence.mednet.ucla.edu/pages/viewpage.action?pageId=84091668).

- [X] I have set up the branch protection rule following the [github standards](https://confluence.mednet.ucla.edu/pages/viewpage.action?spaceKey=BOUTROSLAB&title=GitHub+Standards#GitHubStandards-Branchprotectionrule) before opening this pull request, or the branch protection rule has already been set up.

- [X] I have added my name to the contributors listings in the
``metadata.yaml`` and the ``manifest`` block in the config as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

- [X] I have added the changes included in this pull request to the `CHANGELOG.md` under the next release version or unreleased, and updated the date.

- [X] I have updated the version number in the `metadata.yaml` and config file following [semver](https://semver.org/), or the version number has already been updated. (*Leave it unchecked if you are unsure about new version number and discuss it with the infrastructure team in this PR.*)

- [X] I have tested the pipeline on at least one A-mini sample with "run_delly = true", "run_manta = true", "run_qc = true". For run_delly = true, I have tested "variant_type" set to `gSV`, `gCNV`, and both. The paths to the test config files and output directories were attached below.

<!--- Briefly describe the changes included in this pull request and the paths to the test cases below
 !--- starting with 'Closes #...' if appropriate --->

Closes #...

**Test Results**
	- sample:    A-mini TWGSAMIN000001-T001-S01-F, TWGSAMIN000001-T002-S02-F
	- input csv: /hot/pipeline/development/slurm/pipeline-call-gSV/input/call-gSV-inputs-amini.csv
	- config:  /hot/users/yupan/projects/pipeline-regenotype-gSV-3-pipelines-submodules/pipeline-regenotype-gSV-meta/pipeline-call-gSV/pipeline/config/template.config
	- output:  /hot/pipeline/development/slurm/pipeline-call-gSV/output-amini
