### PR TITLE
Release `v5.1.0`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ All notable changes to the call-gSV pipeline.
 
 ---
 
-## [5.1.0] - 2024-05-23
+## [5.1.0] - 2024-06-10
 ### Changed
 - Use HG003 as test sample for NFTest
 - Update Nextflow configuration test workflows

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to the call-gSV pipeline.
 
 ## [Unreleased]
 
+---
+
+## [5.1.0] - 2024-05-23
 ### Changed
 - Use HG003 as test sample for NFTest
 - Update Nextflow configuration test workflows

--- a/nextflow.config
+++ b/nextflow.config
@@ -4,5 +4,5 @@ manifest {
     name = 'call-gSV'
     author = 'Yu Pan, Tim Sanders, Yael Berkovich, Mohammed Faizal Eeman Mootor'
     description = 'A pipeline to call germline structural variants utilizing Delly and Manta'
-    version = '5.0.0'
+    version = '5.1.0'
 }

--- a/test/configtest-F16.json
+++ b/test/configtest-F16.json
@@ -41,7 +41,7 @@
       "author": "Yu Pan, Tim Sanders, Yael Berkovich, Mohammed Faizal Eeman Mootor",
       "description": "A pipeline to call germline structural variants utilizing Delly and Manta",
       "name": "call-gSV",
-      "version": "5.0.0"
+      "version": "5.1.0"
     },
     "params": {
       "GCNV": "gCNV",
@@ -70,7 +70,7 @@
           ]
         }
       },
-      "log_output_dir": "/tmp/test-only-outputs/call-gSV-5.0.0/8675309/log-call-gSV-5.0.0-19970704T165655Z",
+      "log_output_dir": "/tmp/test-only-outputs/call-gSV-5.1.0/8675309/log-call-gSV-5.1.0-19970704T165655Z",
       "manta_version": "1.6.0",
       "map_qual": "20",
       "mappability_map": "/hot/ref/tool-specific-input/Delly/GRCh38/Homo_sapiens.GRCh38.dna.primary_assembly.fa.r101.s501.blacklist.gz",
@@ -79,7 +79,7 @@
       "min_cpus": "1",
       "min_memory": "1 MB",
       "output_dir": "/tmp/test-only-outputs",
-      "output_dir_base": "/tmp/test-only-outputs/call-gSV-5.0.0/8675309",
+      "output_dir_base": "/tmp/test-only-outputs/call-gSV-5.1.0/8675309",
       "pipeval_version": "4.0.0-rc.2",
       "proc_resource_params": {
         "call_gCNV_Delly": {
@@ -368,15 +368,15 @@
     },
     "report": {
       "enabled": true,
-      "file": "/tmp/test-only-outputs/call-gSV-5.0.0/8675309/log-call-gSV-5.0.0-19970704T165655Z/nextflow-log/report.html"
+      "file": "/tmp/test-only-outputs/call-gSV-5.1.0/8675309/log-call-gSV-5.1.0-19970704T165655Z/nextflow-log/report.html"
     },
     "timeline": {
       "enabled": true,
-      "file": "/tmp/test-only-outputs/call-gSV-5.0.0/8675309/log-call-gSV-5.0.0-19970704T165655Z/nextflow-log/timeline.html"
+      "file": "/tmp/test-only-outputs/call-gSV-5.1.0/8675309/log-call-gSV-5.1.0-19970704T165655Z/nextflow-log/timeline.html"
     },
     "trace": {
       "enabled": true,
-      "file": "/tmp/test-only-outputs/call-gSV-5.0.0/8675309/log-call-gSV-5.0.0-19970704T165655Z/nextflow-log/trace.txt"
+      "file": "/tmp/test-only-outputs/call-gSV-5.1.0/8675309/log-call-gSV-5.1.0-19970704T165655Z/nextflow-log/trace.txt"
     },
     "tz": "sun.util.calendar.ZoneInfo[id=\"UTC\",offset=0,dstSavings=0,useDaylight=false,transitions=0,lastRule=null]",
     "workDir": "/scratch/300935"


### PR DESCRIPTION
# Description
PR to release `v5.1.0`

### Closes #150 

## Testing Results

NFTest log - /hot/software/pipeline/pipeline-call-gSV/Nextflow/development/unreleased/mmootor-release-5-1-0/sbatch-nftest-20240523T180656Z.log

# Checklist
<!--- Please read each of the following items and confirm by replacing the [ ] with a [X] --->

- [x] I have read the [code review guidelines](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3187646/Code+Review+Guidelines) and the [code review best practice on GitHub check-list](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3189956/Code+Review+Best+Practice+on+GitHub+-+Check+List).

- [x] I have reviewed the [Nextflow pipeline standards](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3193890/Nextflow+pipeline+standardization).

- [x] The name of the branch is meaningful and well formatted following the [standards](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3189956/Code+Review+Best+Practice+on+GitHub+-+Check+List), using \[AD_username (or 5 letters of AD if AD is too long)]-\[brief_description_of_branch].

- [x] I have set up or verified the branch protection rule following the [github standards](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3190380/GitHub+Standards#GitHubStandards-Branchprotectionrule) before opening this pull request.

- [x] I have added my name to the contributors listings in the ``manifest`` block in the `nextflow.config` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

- [x] I have added the changes included in this pull request to the `CHANGELOG.md` under the next release version or unreleased, and updated the date.

- [x] I have updated the version number in the `metadata.yaml` and `manifest` block of the `nextflow.config` file following [semver](https://semver.org/), or the version number has already been updated. (*Leave it unchecked if you are unsure about new version number and discuss it with the infrastructure team in this PR.*)

- [x] I have tested the pipeline on at least one A-mini sample with `run_delly = true`, `run_manta = true`, `run_qc = true`. For `run_delly = true`, I have tested 'variant_type' set to `gSV`, `gCNV`, and both. The paths to the test config files and output directories are captured above in the Testing Results section.
