### PR TITLE
Optimize Manta CPU

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to the call-gSV pipeline.
 ---
 
 ## [Unreleased]
+### Changed
+- Increase CPU allocation for Manta
 
 ---
 

--- a/config/F16.config
+++ b/config/F16.config
@@ -24,7 +24,7 @@ process {
             }
         }
     withName: call_gSV_Manta {
-        cpus = 1
+        cpus = 6
         memory = 8.GB
         retry_strategy {
             memory {

--- a/config/F32.config
+++ b/config/F32.config
@@ -24,7 +24,7 @@ process {
             }
         }
     withName: call_gSV_Manta {
-        cpus = 1
+        cpus = 12
         memory = 15.GB
         retry_strategy {
             memory {

--- a/config/F72.config
+++ b/config/F72.config
@@ -24,7 +24,7 @@ process {
             }
         }
     withName: call_gSV_Manta {
-        cpus = 1
+        cpus = 24
         memory = 30.GB
         retry_strategy {
             memory {

--- a/config/M64.config
+++ b/config/M64.config
@@ -24,7 +24,7 @@ process {
             }
         }
     withName: call_gSV_Manta {
-        cpus = 1
+        cpus = 30
         memory = 60.GB
         retry_strategy {
             memory {

--- a/module/manta.nf
+++ b/module/manta.nf
@@ -49,7 +49,7 @@ process call_gSV_Manta {
         --normalBam $input_bam \
         --referenceFasta $reference_fasta \
         --runDir MantaWorkflow
-    MantaWorkflow/runWorkflow.py
+    MantaWorkflow/runWorkflow.py -j ${task.cpus}
 
     # re-name Manta outputs based on output file name standardization - `params.output_filename`
     for variant_file in `ls MantaWorkflow/results/variants/*`

--- a/test/configtest-F16.json
+++ b/test/configtest-F16.json
@@ -111,7 +111,7 @@
           }
         },
         "call_gSV_Manta": {
-          "cpus": "1",
+          "cpus": "6",
           "ext": {
             "retry_codes": []
           },
@@ -304,7 +304,7 @@
         }
       },
       "withName:call_gSV_Manta": {
-        "cpus": "1",
+        "cpus": "6",
         "ext": {
           "retry_codes": []
         },


### PR DESCRIPTION
# Description
Increment CPU allocation for Manta.

The increments in this PR were primarily adapted from pipeline-call-sSNV and tailored to pipeline-call-gSV's requirements.

### Closes #154 

## Testing Results

Node | Sample | BAM Size |Old Runtime (CPU = 1) | New Runtime (CPU = n) |
---|---|---|---|---|
F16 | HG003-5X | 21G | 1h 27m | 11m 38s |
F32 | ILHNLNEV000002-N001-B01-F | 85GB | 7h 38m | 34m |
F72 | ZMBNGIAB000008-N001-A01-F | 369GB | >20h still running | 6h 1m |

output dir: `/hot/software/pipeline/pipeline-call-gSV/Nextflow/development/unreleased/mmootor-optimize-manta-cpu/`

# Checklist
<!--- Please read each of the following items and confirm by replacing the [ ] with a [X] --->

- [x] I have read the [code review guidelines](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3187646/Code+Review+Guidelines) and the [code review best practice on GitHub check-list](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3189956/Code+Review+Best+Practice+on+GitHub+-+Check+List).

- [x] I have reviewed the [Nextflow pipeline standards](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3193890/Nextflow+pipeline+standardization).

- [x] The name of the branch is meaningful and well formatted following the [standards](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3189956/Code+Review+Best+Practice+on+GitHub+-+Check+List), using \[AD_username (or 5 letters of AD if AD is too long)]-\[brief_description_of_branch].

- [x] I have set up or verified the branch protection rule following the [github standards](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3190380/GitHub+Standards#GitHubStandards-Branchprotectionrule) before opening this pull request.

- [x] I have added my name to the contributors listings in the ``manifest`` block in the `nextflow.config` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

- [x] I have added the changes included in this pull request to the `CHANGELOG.md` under the next release version or unreleased, and updated the date.

- [x] I have updated the version number in the `metadata.yaml` and `manifest` block of the `nextflow.config` file following [semver](https://semver.org/), or the version number has already been updated. (*Leave it unchecked if you are unsure about new version number and discuss it with the infrastructure team in this PR.*)

- [x] I have tested the pipeline on at least one A-mini sample with `run_delly = true`, `run_manta = true`, `run_qc = true`. For `run_delly = true`, I have tested 'variant_type' set to `gSV`, `gCNV`, and both. The paths to the test config files and output directories are captured above in the Testing Results section.
