### PR TITLE
Release v5.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to the call-gSV pipeline.
 ---
 
 ## [Unreleased]
+
+---
+
+## [5.2.0] - 2024-07-03
 ### Added
 - Add `methods.modify_base_allocations()` to update resource allocation
 

--- a/README.md
+++ b/README.md
@@ -31,10 +31,11 @@ The call-gSV nextflow pipeline, calls structural variants (SVs) and copy number 
 
 | Config File | Available Node cpus / memory | Designated Process 1; cpus / memory | Designated Process 2; cpus / memory | Designated Process 3; cpus / memory |
 |:------------|:---------|:-------------------------|:-------------------------|:-------------------------|
-| `F2.config` | 2 / 3 GB | call_gSV_Delly; 1 / 2 GB | call_gSV_Manta; 1 / 2 GB\* | validate_file; 1 / 1 GB |
-| `F32.config` | 32 / 62.8 GB | call_gSV_Delly; 1 / 30 GB | call_gSV_Manta; 1 / 30 GB | validate_file; 1 / 1 GB |
-| `F72.config` | 72 / 136.8 GB | call_gSV_Delly; 1 / 65 GB | call_gSV_Manta; 1 / 65 GB | validate_file; 1 / 1 GB |
-| `M64.config` | 64 / 950 GB | call_gSV_Delly; 1 / 470 GB | call_gSV_Manta; 1 / 470 GB | validate_file; 1 / 1 GB |
+| `F2.config` | 2 / 3 GB | call_gSV_Delly; 1 / 2 GB | call_gCNV_Delly; 1 / 2 GB | call_gSV_Manta; 1 / 2 GB\* |
+| `F16.config` | 16 /  GB | call_gSV_Delly; 1 / 8 GB | call_gCNV_Delly; 1 / 8 GB | call_gSV_Manta; 6 / 8 GB\* |
+| `F32.config` | 32 / 62.8 GB | call_gSV_Delly; 1 / 15 GB | call_gCNV_Delly; 1 / 15 GB | call_gSV_Manta; 12 / 15 GB |
+| `F72.config` | 72 / 136.8 GB | call_gSV_Delly; 1 / 30 GB | call_gCNV_Delly; 1 / 30 GB | call_gSV_Manta; 24 / 30 GB |
+| `M64.config` | 64 / 950 GB | call_gSV_Delly; 1 / 60 GB | call_gCNV_Delly; 1 / 60 GB | call_gSV_Manta; 30 / 60 GB |
 ---
 \* Manta SV calling wouldn't work on an F2 node due to incompatible resources. In order to test the pipeline for tasks not relevant to Manta, please set `run_manta = false` in the sample specific [config](config/template.config) file.
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ The call-gSV nextflow pipeline, calls structural variants (SVs) and copy number 
 | Config File | Available Node cpus / memory | Designated Process 1; cpus / memory | Designated Process 2; cpus / memory | Designated Process 3; cpus / memory |
 |:------------|:---------|:-------------------------|:-------------------------|:-------------------------|
 | `F2.config` | 2 / 3 GB | call_gSV_Delly; 1 / 2 GB | call_gCNV_Delly; 1 / 2 GB | call_gSV_Manta; 1 / 2 GB\* |
-| `F16.config` | 16 /  GB | call_gSV_Delly; 1 / 8 GB | call_gCNV_Delly; 1 / 8 GB | call_gSV_Manta; 6 / 8 GB\* |
+| `F16.config` | 16 / 26 GB | call_gSV_Delly; 1 / 8 GB | call_gCNV_Delly; 1 / 8 GB | call_gSV_Manta; 6 / 8 GB\* |
 | `F32.config` | 32 / 62.8 GB | call_gSV_Delly; 1 / 15 GB | call_gCNV_Delly; 1 / 15 GB | call_gSV_Manta; 12 / 15 GB |
 | `F72.config` | 72 / 136.8 GB | call_gSV_Delly; 1 / 30 GB | call_gCNV_Delly; 1 / 30 GB | call_gSV_Manta; 24 / 30 GB |
 | `M64.config` | 64 / 950 GB | call_gSV_Delly; 1 / 60 GB | call_gCNV_Delly; 1 / 60 GB | call_gSV_Manta; 30 / 60 GB |

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ The call-gSV nextflow pipeline, calls structural variants (SVs) and copy number 
 | Config File | Available Node cpus / memory | Designated Process 1; cpus / memory | Designated Process 2; cpus / memory | Designated Process 3; cpus / memory |
 |:------------|:---------|:-------------------------|:-------------------------|:-------------------------|
 | `F2.config` | 2 / 3 GB | call_gSV_Delly; 1 / 2 GB | call_gCNV_Delly; 1 / 2 GB | call_gSV_Manta; 1 / 2 GB\* |
-| `F16.config` | 16 / 26 GB | call_gSV_Delly; 1 / 8 GB | call_gCNV_Delly; 1 / 8 GB | call_gSV_Manta; 6 / 8 GB\* |
+| `F16.config` | 16 / 26 GB | call_gSV_Delly; 1 / 8 GB | call_gCNV_Delly; 1 / 8 GB | call_gSV_Manta; 6 / 8 GB |
 | `F32.config` | 32 / 62.8 GB | call_gSV_Delly; 1 / 15 GB | call_gCNV_Delly; 1 / 15 GB | call_gSV_Manta; 12 / 15 GB |
 | `F72.config` | 72 / 136.8 GB | call_gSV_Delly; 1 / 30 GB | call_gCNV_Delly; 1 / 30 GB | call_gSV_Manta; 24 / 30 GB |
 | `M64.config` | 64 / 950 GB | call_gSV_Delly; 1 / 60 GB | call_gCNV_Delly; 1 / 60 GB | call_gSV_Manta; 30 / 60 GB |

--- a/nextflow.config
+++ b/nextflow.config
@@ -4,5 +4,5 @@ manifest {
     name = 'call-gSV'
     author = 'Yu Pan, Tim Sanders, Yael Berkovich, Mohammed Faizal Eeman Mootor'
     description = 'A pipeline to call germline structural variants utilizing Delly and Manta'
-    version = '5.1.0'
+    version = '5.2.0'
 }


### PR DESCRIPTION
# Description
PR to release pipeline-call-gSV `v5.2.0`.

### Closes #162 

## Testing Results

NFTest - /hot/software/pipeline/pipeline-call-gSV/Nextflow/development/unreleased/mmootor-release-5-2-0/sbatch-nftest-20240703T200504Z.log

# Checklist
<!--- Please read each of the following items and confirm by replacing the [ ] with a [X] --->

- [x] I have read the [code review guidelines](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3187646/Code+Review+Guidelines) and the [code review best practice on GitHub check-list](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3189956/Code+Review+Best+Practice+on+GitHub+-+Check+List).

- [x] I have reviewed the [Nextflow pipeline standards](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3193890/Nextflow+pipeline+standardization).

- [x] The name of the branch is meaningful and well formatted following the [standards](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3189956/Code+Review+Best+Practice+on+GitHub+-+Check+List), using \[AD_username (or 5 letters of AD if AD is too long)]-\[brief_description_of_branch].

- [x] I have set up or verified the branch protection rule following the [github standards](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3190380/GitHub+Standards#GitHubStandards-Branchprotectionrule) before opening this pull request.

- [x] I have added my name to the contributors listings in the ``manifest`` block in the `nextflow.config` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

- [x] I have added the changes included in this pull request to the `CHANGELOG.md` under the next release version or unreleased, and updated the date.

- [x] I have updated the version number in the `metadata.yaml` and `manifest` block of the `nextflow.config` file following [semver](https://semver.org/), or the version number has already been updated. (*Leave it unchecked if you are unsure about new version number and discuss it with the infrastructure team in this PR.*)

- [x] I have tested the pipeline on at least one A-mini sample with `run_delly = true`, `run_manta = true`, `run_qc = true`. For `run_delly = true`, I have tested 'variant_type' set to `gSV`, `gCNV`, and both. The paths to the test config files and output directories are captured above in the Testing Results section.
