### PR TITLE
Update cluster reference paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ input:
 | `run_manta` | true | boolean | Whether or not the workflow should run Manta (either run_delly or run_manta must be set to `true`) |
 | `run_qc` | no | boolean | Optional parameter to indicate whether subsequent quality checks should be run on Delly outputs. Default value is `false`. |
 | `reference_fasta` | yes | path | Absolute path to the reference genome `FASTA` file. The reference genome is used by Delly for SV calling. |
-| `exclusion_file` | yes | path | Absolute path to the delly reference genome `exclusion` file utilized to remove suggested regions for SV calling. On Slurm, an HG38 exclusion file is located at `/hot/ref/tool-specific-input/Delly/hg38/human.hg38.excl.tsv` |
+| `exclusion_file` | yes | path | Absolute path to the delly reference genome `exclusion` file utilized to remove suggested regions for SV calling. On Slurm, an HG38 exclusion file is located at `/hot/resource/tool-specific-input/Delly/hg38/human.hg38.excl.tsv` |
 | `mappability_map` | yes | path | Absolute path to the delly mappability map to support GC and mappability fragment correction in CNV calling |
 | `map_qual` | no | path | minimum paired-end (PE) mapping quaility threshold for Delly. |
 | `save_intermediate_files` | yes | boolean | Optional parameter to indicate whether intermediate files will be saved. Default value is `false`. |
@@ -285,9 +285,9 @@ Testing was performed leveraging aligned and sorted BAMs generated using `bwa-me
 
 Test runs for the A-mini/partial/full samples were performed using the following reference files
 
-* **reference_fasta:** /hot/ref/reference/GRCh38-BI-20160721/Homo_sapiens_assembly38.fasta
-* **exclusion_file:** /hot/ref/tool-specific-input/Delly/GRCh38/human.hg38.excl.tsv
-* **mappability_map:** /hot/ref/tool-specific-input/Delly/GRCh38/Homo_sapiens.GRCh38.dna.primary_assembly.fa.r101.s501.blacklist.gz
+* **reference_fasta:** /hot/resource/reference-genome/GRCh38-BI-20160721/Homo_sapiens_assembly38.fasta
+* **exclusion_file:** /hot/resource/tool-specific-input/Delly/GRCh38/human.hg38.excl.tsv
+* **mappability_map:** /hot/resource/tool-specific-input/Delly/GRCh38/Homo_sapiens.GRCh38.dna.primary_assembly.fa.r101.s501.blacklist.gz
 
 ### Performance Validation
 

--- a/config/template.config
+++ b/config/template.config
@@ -30,10 +30,10 @@ params {
 
     output_dir = "where/to/save/outputs/"
 
-    reference_fasta = "/hot/ref/reference/GRCh38-BI-20160721/Homo_sapiens_assembly38.fasta"
+    reference_fasta = "/hot/resource/reference-genome/GRCh38-BI-20160721/Homo_sapiens_assembly38.fasta"
 
-    exclusion_file = "/hot/ref/tool-specific-input/Delly/GRCh38/human.hg38.excl.tsv"
-    mappability_map = "/hot/ref/tool-specific-input/Delly/GRCh38/Homo_sapiens.GRCh38.dna.primary_assembly.fa.r101.s501.blacklist.gz"
+    exclusion_file = "/hot/resource/tool-specific-input/Delly/GRCh38/human.hg38.excl.tsv"
+    mappability_map = "/hot/resource/tool-specific-input/Delly/GRCh38/Homo_sapiens.GRCh38.dna.primary_assembly.fa.r101.s501.blacklist.gz"
 
     map_qual = 20 // min. paired-end (PE) mapping quality for Delly
 

--- a/test/config/base-resource-update.config
+++ b/test/config/base-resource-update.config
@@ -28,10 +28,10 @@ params {
 
     save_intermediate_files = false
 
-    reference_fasta = "/hot/ref/reference/GRCh38-BI-20160721/Homo_sapiens_assembly38.fasta"
+    reference_fasta = "/hot/resource/reference-genome/GRCh38-BI-20160721/Homo_sapiens_assembly38.fasta"
 
-    exclusion_file = "/hot/ref/tool-specific-input/Delly/GRCh38/human.hg38.excl.tsv"
-    mappability_map = "/hot/ref/tool-specific-input/Delly/GRCh38/Homo_sapiens.GRCh38.dna.primary_assembly.fa.r101.s501.blacklist.gz"
+    exclusion_file = "/hot/resource/tool-specific-input/Delly/GRCh38/human.hg38.excl.tsv"
+    mappability_map = "/hot/resource/tool-specific-input/Delly/GRCh38/Homo_sapiens.GRCh38.dna.primary_assembly.fa.r101.s501.blacklist.gz"
 
     map_qual = 20 // min. paired-end (PE) mapping quality for Delly
 

--- a/test/config/gsv_discovery-all-tools.config
+++ b/test/config/gsv_discovery-all-tools.config
@@ -28,10 +28,10 @@ params {
 
     save_intermediate_files = false
 
-    reference_fasta = "/hot/ref/reference/GRCh38-BI-20160721/Homo_sapiens_assembly38.fasta"
+    reference_fasta = "/hot/resource/reference-genome/GRCh38-BI-20160721/Homo_sapiens_assembly38.fasta"
 
-    exclusion_file = "/hot/ref/tool-specific-input/Delly/GRCh38/human.hg38.excl.tsv"
-    mappability_map = "/hot/ref/tool-specific-input/Delly/GRCh38/Homo_sapiens.GRCh38.dna.primary_assembly.fa.r101.s501.blacklist.gz"
+    exclusion_file = "/hot/resource/tool-specific-input/Delly/GRCh38/human.hg38.excl.tsv"
+    mappability_map = "/hot/resource/tool-specific-input/Delly/GRCh38/Homo_sapiens.GRCh38.dna.primary_assembly.fa.r101.s501.blacklist.gz"
 
     map_qual = 20 // min. paired-end (PE) mapping quality for Delly
 

--- a/test/config/gsv_discovery-delly.config
+++ b/test/config/gsv_discovery-delly.config
@@ -28,10 +28,10 @@ params {
 
     save_intermediate_files = false
 
-    reference_fasta = "/hot/ref/reference/GRCh38-BI-20160721/Homo_sapiens_assembly38.fasta"
+    reference_fasta = "/hot/resource/reference-genome/GRCh38-BI-20160721/Homo_sapiens_assembly38.fasta"
 
-    exclusion_file = "/hot/ref/tool-specific-input/Delly/GRCh38/human.hg38.excl.tsv"
-    mappability_map = "/hot/ref/tool-specific-input/Delly/GRCh38/Homo_sapiens.GRCh38.dna.primary_assembly.fa.r101.s501.blacklist.gz"
+    exclusion_file = "/hot/resource/tool-specific-input/Delly/GRCh38/human.hg38.excl.tsv"
+    mappability_map = "/hot/resource/tool-specific-input/Delly/GRCh38/Homo_sapiens.GRCh38.dna.primary_assembly.fa.r101.s501.blacklist.gz"
 
     map_qual = 20 // min. paired-end (PE) mapping quality for Delly
 

--- a/test/config/gsv_discovery-manta.config
+++ b/test/config/gsv_discovery-manta.config
@@ -28,10 +28,10 @@ params {
 
     save_intermediate_files = false
 
-    reference_fasta = "/hot/ref/reference/GRCh38-BI-20160721/Homo_sapiens_assembly38.fasta"
+    reference_fasta = "/hot/resource/reference-genome/GRCh38-BI-20160721/Homo_sapiens_assembly38.fasta"
 
-    exclusion_file = "/hot/ref/tool-specific-input/Delly/GRCh38/human.hg38.excl.tsv"
-    mappability_map = "/hot/ref/tool-specific-input/Delly/GRCh38/Homo_sapiens.GRCh38.dna.primary_assembly.fa.r101.s501.blacklist.gz"
+    exclusion_file = "/hot/resource/tool-specific-input/Delly/GRCh38/human.hg38.excl.tsv"
+    mappability_map = "/hot/resource/tool-specific-input/Delly/GRCh38/Homo_sapiens.GRCh38.dna.primary_assembly.fa.r101.s501.blacklist.gz"
 
     map_qual = 20 // min. paired-end (PE) mapping quality for Delly
 

--- a/test/configtest-F16.json
+++ b/test/configtest-F16.json
@@ -70,7 +70,7 @@
       "docker_image_rtgtools": "ghcr.io/uclahs-cds/rtg-tools:3.12",
       "docker_image_validate": "ghcr.io/uclahs-cds/pipeval:4.0.0-rc.2",
       "docker_image_vcftools": "ghcr.io/uclahs-cds/vcftools:0.1.16",
-      "exclusion_file": "/hot/ref/tool-specific-input/Delly/GRCh38/human.hg38.excl.tsv",
+      "exclusion_file": "/hot/resource/tool-specific-input/Delly/GRCh38/human.hg38.excl.tsv",
       "input": {
         "BAM": {
           "normal": [
@@ -81,7 +81,7 @@
       "log_output_dir": "/tmp/test-only-outputs/call-gSV-VER.SI.ON/8675309/log-call-gSV-VER.SI.ON-19970704T165655Z",
       "manta_version": "1.6.0",
       "map_qual": "20",
-      "mappability_map": "/hot/ref/tool-specific-input/Delly/GRCh38/Homo_sapiens.GRCh38.dna.primary_assembly.fa.r101.s501.blacklist.gz",
+      "mappability_map": "/hot/resource/tool-specific-input/Delly/GRCh38/Homo_sapiens.GRCh38.dna.primary_assembly.fa.r101.s501.blacklist.gz",
       "max_cpus": "16",
       "max_memory": "31 GB",
       "min_cpus": "1",
@@ -188,7 +188,7 @@
           "memory": "1 GB"
         }
       },
-      "reference_fasta": "/hot/ref/reference/GRCh38-BI-20160721/Homo_sapiens_assembly38.fasta",
+      "reference_fasta": "/hot/resource/reference-genome/GRCh38-BI-20160721/Homo_sapiens_assembly38.fasta",
       "rtgtools_version": "3.12",
       "run_delly": true,
       "run_discovery": true,

--- a/test/yaml/gsv-manta-input-a-mini.yaml
+++ b/test/yaml/gsv-manta-input-a-mini.yaml
@@ -2,4 +2,4 @@
 input:
   BAM:
     normal:
-      - "/hot/resource/SMC-HET/normal/bams/A-mini/n1/output/HG002.N-n1.bam"
+      - "/hot/data/unregistered/SMC-HET/normal/bams/A-mini/n1/output/HG002.N-n1.bam"


### PR DESCRIPTION
This PR updates reference paths that were renamed during the most recent cluster downtime.

I was specifically looking for single lines containing one (or more) of the following keys, so I missed any paths split across multiple lines.

| Search String                                                  |
|----------------------------------------------------------------|
| `/hot/ref/`                                                    |
| `/hot/ref/cohort/TCGA/CCG-AIM/`                                |
| `/hot/ref/cohort/TCGA/PanCanAtlas/`                            |
| `/hot/ref/database/1000Genomes/`                               |
| `/hot/ref/database/GDC-34.0 `                                  |
| `/hot/ref/database/GDC-34.0/`                                  |
| `/hot/ref/database/PCAWG/`                                     |
| `/hot/ref/database/ProstateTumor/Boutros-Yamaguchi-PRAD-CPCG/` |
| `/hot/ref/reference/`                                          |
| `/hot/resource/SMC-HET/`                                       |

A table of updated filepaths and whether or not they resolve to a file is included below. Where the original paths still exist due to symlinks I verified that they resolve to the same file as the updated path.

| Original                                                                                                       |                    | Updated                                                                                                             |                    |
|----------------------------------------------------------------------------------------------------------------|--------------------|---------------------------------------------------------------------------------------------------------------------|--------------------|
| `/hot/ref/reference/GRCh38-BI-20160721/Homo_sapiens_assembly38.fasta`                                          | :white_check_mark: | `/hot/resource/reference-genome/GRCh38-BI-20160721/Homo_sapiens_assembly38.fasta`                                   | :white_check_mark: |
| `/hot/ref/tool-specific-input/Delly/GRCh38/human.hg38.excl.tsv`                                                | :white_check_mark: | `/hot/resource/tool-specific-input/Delly/GRCh38/human.hg38.excl.tsv`                                                | :white_check_mark: |
| `/hot/ref/tool-specific-input/Delly/GRCh38/Homo_sapiens.GRCh38.dna.primary_assembly.fa.r101.s501.blacklist.gz` | :white_check_mark: | `/hot/resource/tool-specific-input/Delly/GRCh38/Homo_sapiens.GRCh38.dna.primary_assembly.fa.r101.s501.blacklist.gz` | :white_check_mark: |
| `/hot/ref/tool-specific-input/Delly/hg38/human.hg38.excl.tsv`                                                  | :white_check_mark: | `/hot/resource/tool-specific-input/Delly/hg38/human.hg38.excl.tsv`                                                  | :white_check_mark: |
| `/hot/resource/SMC-HET/normal/bams/A-mini/n1/output/HG002.N-n1.bam`                                            | :white_check_mark: | `/hot/data/unregistered/SMC-HET/normal/bams/A-mini/n1/output/HG002.N-n1.bam`                                        | :white_check_mark: |